### PR TITLE
Veracode SCA: fixes for vulnerable libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<!-- Component Version Properties -->
 	<properties>
-		<spring.version>4.3.10.RELEASE</spring.version>
+		<spring.version>4.3.20.RELEASE</spring.version>
 		<fileupload.version>1.3.2</fileupload.version>
 	</properties>
 
@@ -137,7 +137,7 @@
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-saml-core</artifactId>
-			<version>1.8.1.Final</version>
+			<version>2.5.5.Final</version>
 		</dependency>
 
 		<dependency>
@@ -154,7 +154,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-collections4</artifactId>
-			<version>4.0</version>
+			<version>4.1</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This pull request was generated by Veracode SCA to upgrade the following vulnerable libraries:

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `org.springframework:spring-core` | 4.3.10.RELEASE | 5.2.18.RELEASE | No |
| MAVEN | `org.springframework:spring-webmvc` | 4.3.10.RELEASE | 4.3.20.RELEASE | No |
| MAVEN | `org.keycloak:keycloak-saml-core` | 1.8.1.Final | 2.5.5.Final | No |
| MAVEN | `org.apache.commons:commons-collections4` | 4.0 | 4.1 | No |

Note that we only upgrade libraries which have versions without any known vulnerabilities. For more information, please see the corresponding [Veracode SCA report](https://sca.analysiscenter.veracode.com/teams/K77HX5M/scans/64052747).

The **Breaking** column states the likelihood that updating to the recommended library version will cause breaking changes in your code. Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/r/About_Automatic_Pull_Requests) for documentation.

Note: this pull request was generated because you or someone else with access to this repository granted Veracode SCA access to submit pull requests.
<!-- srcclr-pr-id-46ff0cae692b83dd9f3e635a6db7233afa5ae044e0228f9f9397bf758126b283 -->
